### PR TITLE
fix for issue#7. tested on chrome/safari/firefox

### DIFF
--- a/src/hello-world.html
+++ b/src/hello-world.html
@@ -8,7 +8,7 @@
         var thatDoc = document;
 
         // Refers to the "importee", which is src/hello-world.html
-        var thisDoc =  (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+        var thisDoc =  (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
 
         // Gets content from <template>
         var template = thisDoc.querySelector('template').content;


### PR DESCRIPTION
fixes issue#7: use _currentScript (from the polyfills) to get the ownerDocument. if polyfills do not exist, use currentScript instead. 